### PR TITLE
[OJ-27534] [OJ-27499]: Patches to Prefect to configure DB connection pool and optimize /task_runs endpoint

### DIFF
--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -14,6 +14,8 @@ from prefect.settings import (
     PREFECT_API_DATABASE_CONNECTION_TIMEOUT,
     PREFECT_API_DATABASE_ECHO,
     PREFECT_API_DATABASE_TIMEOUT,
+    PREFECT_SQLALCHEMY_POOL_SIZE,
+    PREFECT_SQLALCHEMY_MAX_OVERFLOW,
 )
 from prefect.utilities.asyncutils import add_event_loop_shutdown_callback
 
@@ -37,12 +39,20 @@ class BaseDatabaseConfiguration(ABC):
         echo: bool = None,
         timeout: float = None,
         connection_timeout: float = None,
+        sqlalchemy_pool_size: int = None,
+        sqlalchemy_max_overflow: int = None,
     ):
         self.connection_url = connection_url
         self.echo = echo or PREFECT_API_DATABASE_ECHO.value()
         self.timeout = timeout or PREFECT_API_DATABASE_TIMEOUT.value()
         self.connection_timeout = (
             connection_timeout or PREFECT_API_DATABASE_CONNECTION_TIMEOUT.value()
+        )
+        self.sqlalchemy_pool_size = (
+            sqlalchemy_pool_size or PREFECT_SQLALCHEMY_POOL_SIZE.value()
+        )
+        self.sqlalchemy_max_overflow = (
+            sqlalchemy_max_overflow or PREFECT_SQLALCHEMY_MAX_OVERFLOW.value()
         )
 
     def _unique_key(self) -> Tuple[Hashable, ...]:
@@ -121,6 +131,12 @@ class AsyncPostgresConfiguration(BaseDatabaseConfiguration):
             if connect_args:
                 connect_args["server_settings"] = {"jit": "off"}
                 kwargs["connect_args"] = connect_args
+
+            if self.sqlalchemy_pool_size is not None:
+                kwargs["pool_size"] = self.sqlalchemy_pool_size
+
+            if self.sqlalchemy_max_overflow is not None:
+                kwargs["max_overflow"] = self.sqlalchemy_max_overflow
 
             engine = create_async_engine(self.connection_url, echo=self.echo, **kwargs)
 

--- a/src/prefect/server/models/task_runs.py
+++ b/src/prefect/server/models/task_runs.py
@@ -11,6 +11,7 @@ import sqlalchemy as sa
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from prefect.logging import get_logger
 import prefect.server.models as models
 import prefect.server.schemas as schemas
 from prefect.server.database.dependencies import inject_db
@@ -21,6 +22,8 @@ from prefect.server.orchestration.global_policy import GlobalTaskPolicy
 from prefect.server.orchestration.policies import BaseOrchestrationPolicy
 from prefect.server.orchestration.rules import TaskOrchestrationContext
 from prefect.server.schemas.responses import OrchestrationResult
+
+logger = get_logger("server")
 
 
 @inject_db
@@ -153,6 +156,19 @@ async def _apply_task_run_filters(
     if task_run_filter:
         query = query.where(task_run_filter.as_sql_filter(db))
 
+    # Return a simplified query in the case that the request is ONLY asking to filter on flow_run_id (and task_run_filter)
+    # In this case there's no need to generate the complex EXISTS subqueries; the generated query here is much more efficient
+    if (
+        flow_run_filter
+        and flow_run_filter.only_filters_on_id()
+        and not any(
+            [flow_filter, deployment_filter, work_pool_filter, work_queue_filter]
+        )
+    ):
+        query = query.where(db.TaskRun.flow_run_id == str(flow_run_filter.id.any_[0]))
+
+        return query
+
     if (
         flow_filter
         or flow_run_filter
@@ -243,6 +259,7 @@ async def read_task_runs(
     if limit is not None:
         query = query.limit(limit)
 
+    logger.debug(f"In read_task_runs, query generated is:\n{query}")
     result = await session.execute(query)
     return result.scalars().unique().all()
 

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -504,6 +504,22 @@ class FlowRunFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `FlowRun.idempotency_key`"
     )
 
+    def only_filters_on_id(self):
+        return (
+            self.id is not None
+            and self.name is None
+            and self.tags is None
+            and self.deployment_id is None
+            and self.work_queue_name is None
+            and self.state is None
+            and self.flow_version is None
+            and self.start_time is None
+            and self.expected_start_time is None
+            and self.next_scheduled_start_time is None
+            and self.parent_task_run_id is None
+            and self.idempotency_key is None
+        )
+
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
         filters = []
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -826,6 +826,28 @@ The following options are available:
 - "ignore": Do not log a warning message or raise an error.
 """
 
+PREFECT_SQLALCHEMY_POOL_SIZE = Setting(
+    int,
+    default=None,
+)
+"""
+When creating a SQLAlchemy engine to connect to PostgreSQL, this value will be passed as the pool_size argument.
+
+If None the pool_size argument will not be passed to the engine; in this case SQLAlchemy will (currently anyway)
+default it to 5.
+"""
+
+PREFECT_SQLALCHEMY_MAX_OVERFLOW = Setting(
+    int,
+    default=None,
+)
+"""
+When creating a SQLAlchemy engine to connect to PostgreSQL, this value will be passed as the max_overflow argument.
+
+If None the max_overflow argument will not be passed to the engine; in this case SQLAlchemy will (currently anyway)
+default it to 10.
+"""
+
 PREFECT_LOGGING_COLORS = Setting(
     bool,
     default=True,


### PR DESCRIPTION
**Code Changes**

Two changes made on top of Prefect's most-recent 2.11.3 release.

1. Allow DB connection pool settings to be customized

Add settings for `PREFECT_SQLALCHEMY_POOL_SIZE` and `PREFECT_SQLALCHEMY_MAX_OVERFLOW`; when creating a SQLAlchemy engine, pass these as the `pool_size` and `max_overflow` kwargs.

This same commit was put into [this PR](https://github.com/PrefectHQ/prefect/pull/10348) against Prefect's repository. The issue it's addressing has been reported by multiple customers in GitHub and in Slack. The hope is that if we go live with this change in our infra and prove that it addresses the connection pool concerns that'll be fuel to get the PR paid attention to and merged upstream.

2. Optimize the `/task_runs` endpoint

Optimize the query generation used to fetch task runs (used, e.g., by the `/task_runs` endpoint) -- in the (common) case that the client wants to filter task runs ONLY on `flow_run_id`, generate a much simpler and more efficient query.

The change here makes the query that's generated by this endpoint ~65x faster in a local development environment. It's expected that this will have a similarly large performance improvement in production, where the table queried by `/task_runs` is substantially larger. Our data refresh history page calls into the `/task_runs` endpoint frequently; the performance of the data refresh history page will be monitored post-rollout to confirm this change gets us the expected performance boost. If so then I'll open another PR against Prefect's repository to suggest that this change gets incorporated (other community users have also reported slow performance of `/task_runs`).

**Rollout Plan**

1. Merge this PR into the 2.11.3-patched branch in our forked repo

2. Switch our infra to run Prefect Server from the Docker image built from this branch (this will come in a separate PR)

3. Do NOT yet configure the new connection pool settings

4. Measure the effect of the optimization to `/task_runs` -- this should be evident by checking on the performance of the `/data-refreshes` endpoint in the Jellyfish app (that will be checked via this [Honeycomb board](https://ui.honeycomb.io/jellyfish/board/kgf5SB7NHWh/Matt-data-refreshes-endpoint)).

5. Put through an infra change to start passing the new arguments `PREFECT_SQLALCHEMY_POOL_SIZE` and `PREFECT_SQLALCHEMY_MAX_OVERFLOW` to the Prefect Server startup (to large values)

6. Validate that the existing setup -- three Prefect Server instances -- is stable and otherwise unaffected

7. Dial back the number of Prefect Server instances to two and then one; validate that the number of DB connections doesn't hit a bound, and that the Prefect Server tasks don't get pinned on CPU.
