### PR TITLE
truncate the whole message

### DIFF
--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -213,7 +213,7 @@ async def exception_to_failed_state(
 
     # TODO: Consider if we want to include traceback information, it is intentionally
     #       excluded from messages for now
-    message = existing_message + format_exception(exc)
+    message = truncated_to(PREFECT_MESSAGE_TRUNCATE_LENGTH.value(), existing_message + format_exception(exc))
 
     return Failed(data=data, message=message, **kwargs)
 


### PR DESCRIPTION
the previous change truncated the formatted exception, but we still have the potential to append that truncated exception to an existing message which is un-truncated
