### PR TITLE
fix truncation bug

### DIFF
--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -213,7 +213,9 @@ async def exception_to_failed_state(
 
     # TODO: Consider if we want to include traceback information, it is intentionally
     #       excluded from messages for now
-    message = existing_message + format_exception(exc)
+    message = truncated_to(
+        PREFECT_MESSAGE_TRUNCATE_LENGTH.value(), existing_message + format_exception(exc)
+    )
 
     return Failed(data=data, message=message, **kwargs)
 

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -13,10 +13,7 @@ from typing_extensions import TypeGuard
 
 from prefect.client.schemas import State as State
 from prefect.client.schemas import StateDetails, StateType
-from prefect.deprecated.data_documents import (
-    DataDocument,
-    result_from_state_with_data_document,
-)
+from prefect.deprecated.data_documents import DataDocument, result_from_state_with_data_document
 from prefect.exceptions import (
     CancelledRun,
     CrashedRun,
@@ -27,10 +24,7 @@ from prefect.exceptions import (
     UnfinishedRun,
 )
 from prefect.results import BaseResult, R, ResultFactory
-from prefect.settings import (
-    PREFECT_ASYNC_FETCH_STATE_RESULT,
-    PREFECT_MESSAGE_TRUNCATE_LENGTH,
-)
+from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT, PREFECT_MESSAGE_TRUNCATE_LENGTH
 from prefect.utilities.annotations import BaseAnnotation
 from prefect.utilities.asyncutils import in_async_main_thread, sync_compatible
 from prefect.utilities.collections import ensure_iterable
@@ -213,7 +207,7 @@ async def exception_to_failed_state(
 
     # TODO: Consider if we want to include traceback information, it is intentionally
     #       excluded from messages for now
-    message = existing_message + format_exception(exc)
+    message = truncated_to(PREFECT_MESSAGE_TRUNCATE_LENGTH.value(), existing_message + format_exception(exc))
 
     return Failed(data=data, message=message, **kwargs)
 

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -13,7 +13,10 @@ from typing_extensions import TypeGuard
 
 from prefect.client.schemas import State as State
 from prefect.client.schemas import StateDetails, StateType
-from prefect.deprecated.data_documents import DataDocument, result_from_state_with_data_document
+from prefect.deprecated.data_documents import (
+    DataDocument,
+    result_from_state_with_data_document,
+)
 from prefect.exceptions import (
     CancelledRun,
     CrashedRun,
@@ -24,7 +27,10 @@ from prefect.exceptions import (
     UnfinishedRun,
 )
 from prefect.results import BaseResult, R, ResultFactory
-from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT, PREFECT_MESSAGE_TRUNCATE_LENGTH
+from prefect.settings import (
+    PREFECT_ASYNC_FETCH_STATE_RESULT,
+    PREFECT_MESSAGE_TRUNCATE_LENGTH,
+)
 from prefect.utilities.annotations import BaseAnnotation
 from prefect.utilities.asyncutils import in_async_main_thread, sync_compatible
 from prefect.utilities.collections import ensure_iterable
@@ -207,7 +213,7 @@ async def exception_to_failed_state(
 
     # TODO: Consider if we want to include traceback information, it is intentionally
     #       excluded from messages for now
-    message = truncated_to(PREFECT_MESSAGE_TRUNCATE_LENGTH.value(), existing_message + format_exception(exc))
+    message = existing_message + format_exception(exc)
 
     return Failed(data=data, message=message, **kwargs)
 

--- a/src/prefect/utilities/text.py
+++ b/src/prefect/utilities/text.py
@@ -8,12 +8,8 @@ def truncated_to(length: int, value: Optional[str]) -> str:
     if len(value) <= length:
         return value
 
-    half = length // 2
+    help_text = "...[truncated]..."
 
-    beginning = value[:half]
-    end = value[-half:]
-    omitted = len(value) - (len(beginning) + len(end))
+    truncated = value[: length - len(help_text)]
 
-    proposed = f"{beginning}...{omitted} additional characters...{end}"
-
-    return proposed if len(proposed) < len(value) else value
+    return truncated + help_text if len(truncated) < len(help_text) else value[:length]

--- a/src/prefect/utilities/text.py
+++ b/src/prefect/utilities/text.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+HELP_TEXT = "...[truncated]..."
+
 
 def truncated_to(length: int, value: Optional[str]) -> str:
     if not value:
@@ -8,8 +10,8 @@ def truncated_to(length: int, value: Optional[str]) -> str:
     if len(value) <= length:
         return value
 
-    help_text = "...[truncated]..."
-
-    truncated = value[: length - len(help_text)]
-
-    return truncated + help_text if len(truncated) < len(help_text) else value[:length]
+    return (
+        value[: length - len(HELP_TEXT)] + HELP_TEXT
+        if len(HELP_TEXT) < length
+        else value[:length]
+    )

--- a/tests/utilities/test_text.py
+++ b/tests/utilities/test_text.py
@@ -1,0 +1,29 @@
+from prefect.utilities.text import HELP_TEXT, truncated_to
+
+
+class TestTruncatedTo:
+    def test_empty_value(self):
+        value = None
+        length = 100
+        trunc = truncated_to(length, value)
+        assert trunc == ""
+
+    def test_length_exceeds_value(self):
+        value = "a" * 50
+        length = 51
+        trunc = truncated_to(length, value)
+        assert trunc == value
+
+    def test_normal_truncation(self):
+        value = "a" * 100
+        length = 50
+        trunc = truncated_to(length, value)
+        assert len(trunc) == length
+        assert trunc.endswith(HELP_TEXT)
+
+    def test_truncation_help_text_too_long(self):
+        value = "a" * 100
+        length = 10
+        trunc = truncated_to(length, value)
+        assert len(trunc) == length
+        assert trunc == "a" * length


### PR DESCRIPTION
the `truncated_to` util that we are using to try and trim message text written to the database is bugged.

the old function yanks text from the middle of the string to truncate to the desired length. it then concatenates the two halves of the string with some helper text in the middle, which pushes the length of the string past the desired length. the return line then returns the new string if its under the desired length and the original string otherwise.

the outcome here is we almost always return the original string if we get into the truncation logic.

this change now truncates the string from the end and inserts helper text if it can fit. if the desired length is shorter then the length of the helper text, we just truncated the original string.

four tests added to confirm this works:

```
(jellyfish) ip-10-0-0-71~/jellyfish-source/prefect(bdr--truncation-bug|✚1…) % pytest tests/utilities/test_text.py
======================================================================= test session starts =======================================================================
platform darwin -- Python 3.10.10, pytest-7.4.2, pluggy-1.3.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/brianreid/jellyfish-source/prefect
configfile: setup.cfg
plugins: timeout-2.2.0, respx-0.20.2, flaky-3.7.0, env-1.0.1, flakefinder-1.1.0, cov-4.1.0, Faker-19.8.0, asyncio-0.21.1, anyio-3.7.1, requests-mock-1.11.0, hypothesis-6.87.3, xdist-3.3.1, benchmark-4.0.0
timeout: 60.0s
timeout method: signal
timeout func_only: False
asyncio: mode=auto
collected 4 items                                                                                                                                                 

tests/utilities/test_text.py ....                                                                                                                           [100%]

======================================================================= 4 passed in 18.66s ========================================================================
```
